### PR TITLE
Fix duplicate id="logout-form" in "combo" layout mode

### DIFF
--- a/resources/views/partials/header/top-right.blade.php
+++ b/resources/views/partials/header/top-right.blade.php
@@ -30,12 +30,12 @@
             <div class="dropdown-divider"></div>
             <a href="{{$setting_url}}" class="dropdown-item">Settings</a>
             <a class="dropdown-item"
-               href="#" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+               href="#" onclick="event.preventDefault(); document.getElementById('logout-form-{{ uniqid('logout-form-') }}').submit();">
                 <i class="fa fa-fw fa-power-off text-red"></i>
                 {{ __('tablar::tablar.log_out') }}
             </a>
 
-            <form id="logout-form" action="{{ $logout_url }}" method="POST" style="display: none;">
+            <form id="logout-form-{{ uniqid('logout-form-') }}" action="{{ $logout_url }}" method="POST" style="display: none;">
                 @if(config('tablar.logout_method'))
                     {{ method_field(config('tablar.logout_method')) }}
                 @endif


### PR DESCRIPTION
Description:
This PR resolves the issue of duplicate id="logout-form" when top-right.blade.php is included multiple times in "combo" layout mode. The issue is caused by the inclusion of the same file in both sidebar.blade.php and sidebar-top.blade.php.

To fix this, the logout form's ID is now dynamically generated using uniqid() to ensure uniqueness. This prevents browser console errors and ensures that the DOM remains valid.

Linked Issue:
This PR addresses [Issue #67](https://github.com/takielias/tablar/issues/67).

Steps to Verify:
Enable "combo" layout mode by setting 'layout_enable_top_header' => true in the Tablar configuration.
Verify that the logout forms now have unique IDs and the functionality works as expected.