### PR TITLE
Revert "Fix duplicate id="logout-form" in "combo" layout mode"

### DIFF
--- a/resources/views/partials/header/top-right.blade.php
+++ b/resources/views/partials/header/top-right.blade.php
@@ -30,12 +30,12 @@
             <div class="dropdown-divider"></div>
             <a href="{{$setting_url}}" class="dropdown-item">Settings</a>
             <a class="dropdown-item"
-               href="#" onclick="event.preventDefault(); document.getElementById('logout-form-{{ uniqid('logout-form-') }}').submit();">
+               href="#" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                 <i class="fa fa-fw fa-power-off text-red"></i>
                 {{ __('tablar::tablar.log_out') }}
             </a>
 
-            <form id="logout-form-{{ uniqid('logout-form-') }}" action="{{ $logout_url }}" method="POST" style="display: none;">
+            <form id="logout-form" action="{{ $logout_url }}" method="POST" style="display: none;">
                 @if(config('tablar.logout_method'))
                     {{ method_field(config('tablar.logout_method')) }}
                 @endif


### PR DESCRIPTION
Reverts takielias/tablar#79

Hi,

I must apologize as I didn’t properly test the pull request I recently submitted, and I sincerely regret the oversight. The issue lies in how the logout functionality is implemented, and the merged modification prevents the logout from working correctly. This needs to be reverted.

Additionally, the root problem should be addressed more thoroughly. The ideal solution would be to ensure the logout form is included only once in the layout to avoid duplication. Alternatively, we could use a single PHP variable to generate a unique ID that is then used consistently for both the link and the form. For example:

```blade
@php
    $logoutFormId = 'logout-form-'.uniqid();
@endphp

<div class="dropdown-divider"></div>
<a class="dropdown-item"
   href="#" onclick="event.preventDefault(); document.getElementById('{{ $logoutFormId }}').submit();">
    <i class="fa fa-fw fa-power-off text-red"></i>
    {{ __('tablar::tablar.log_out') }}
</a>

<form id="{{ $logoutFormId }}" action="{{ $logout_url }}" method="POST" style="display: none;">
    @if(config('tablar.logout_method'))
        {{ method_field(config('tablar.logout_method')) }}
    @endif
    {{ csrf_field() }}
</form>
```

Once again, I apologize for the inconvenience caused.

Best regards,  
Giulio